### PR TITLE
Refactor kingdom API responses

### DIFF
--- a/ExamSimulation/src/main/java/com/tecnocampus/examsimulation/api/KingdomRestController.java
+++ b/ExamSimulation/src/main/java/com/tecnocampus/examsimulation/api/KingdomRestController.java
@@ -19,26 +19,29 @@ public class KingdomRestController {
 
     // 1. Create Kingdom
     @PostMapping
-    public ResponseEntity<Void> createKingdom(@RequestBody Kingdom kingdom) {
-        kingdomService.createKingdom(kingdom);
-        return new ResponseEntity<>(HttpStatus.CREATED);
+    public ResponseEntity<Kingdom> createKingdom(@RequestBody Kingdom kingdom) {
+        Kingdom created = kingdomService.createKingdom(kingdom);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
     }
 
     // 2. Start Daily Production
     @PostMapping("/{id}")
-    public ResponseEntity<Void> startDailyProduction(@PathVariable String id) throws NotFoundException {
-        kingdomService.startDailyProduction(id);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<Kingdom> startDailyProduction(@PathVariable String id) throws NotFoundException {
+        Kingdom updated = kingdomService.startDailyProduction(id);
+        if (updated == null) {
+            return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).build();
+        }
+        return ResponseEntity.ok(updated);
     }
 
     // 3. Invest in Food or Citizens
     @PostMapping("/{id}/invest")
-    public ResponseEntity<Void> invest(
+    public ResponseEntity<Kingdom> invest(
             @PathVariable String id,
             @RequestParam String type,
             @RequestBody GoldRequest request) throws NotFoundException {
-        kingdomService.invest(id, type, request.gold());
-        return ResponseEntity.ok().build();
+        Kingdom updated = kingdomService.invest(id, type, request.gold());
+        return ResponseEntity.ok(updated);
     }
 
     // 4. Get Kingdom Status
@@ -55,10 +58,10 @@ public class KingdomRestController {
 
     // 6. Attack another Kingdom
     @PostMapping("/{id}/attack/{target_id}")
-    public ResponseEntity<Void> attack(@PathVariable("id") String attackerId,
+    public ResponseEntity<Kingdom> attack(@PathVariable("id") String attackerId,
                                        @PathVariable("target_id") String defenderId) throws NotFoundException {
-        kingdomService.attack(attackerId, defenderId);
-        return ResponseEntity.ok().build();
+        Kingdom attacker = kingdomService.attack(attackerId, defenderId);
+        return ResponseEntity.ok(attacker);
     }
 
     // DTO para la inversión

--- a/ExamSimulation/src/main/java/com/tecnocampus/examsimulation/domain/Kingdom.java
+++ b/ExamSimulation/src/main/java/com/tecnocampus/examsimulation/domain/Kingdom.java
@@ -4,13 +4,15 @@ import com.tecnocampus.examsimulation.application.DTO.KingdomDTO;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.springframework.data.relational.core.mapping.Column;
 
 public class Kingdom {
     private String id = UUID.randomUUID().toString();
     private int food;
     private int citizens;
     private int gold;
-    private LocalDateTime createdAt = LocalDateTime.now();
+    @Column("created_at")
+    private LocalDateTime dateOfCreation = LocalDateTime.now();
 
     public Kingdom() {
     }
@@ -41,7 +43,7 @@ public class Kingdom {
     public void setGold(int gold) {
         this.gold = gold;
     }
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
+    public LocalDateTime getDateOfCreation() {
+        return dateOfCreation;
     }
 }

--- a/ExamSimulation/src/main/java/com/tecnocampus/examsimulation/persistence/KingdomRepository.java
+++ b/ExamSimulation/src/main/java/com/tecnocampus/examsimulation/persistence/KingdomRepository.java
@@ -21,7 +21,7 @@ public class KingdomRepository {
                 .param("food", kingdom.getFood())
                 .param("gold", kingdom.getGold())
                 .param("citizens", kingdom.getCitizens())
-                .param("created_at", kingdom.getCreatedAt())
+                .param("created_at", kingdom.getDateOfCreation())
                 .update();
     }
 


### PR DESCRIPTION
## Summary
- return kingdoms in REST responses
- propagate errors via HTTP 406
- map `dateOfCreation` property

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684f44c55fb48327918aefe66ec8b054